### PR TITLE
Fix for newer versions of mcstatus

### DIFF
--- a/autosuspend_mcstatus/activity.py
+++ b/autosuspend_mcstatus/activity.py
@@ -18,7 +18,7 @@ class ServerOnline(Activity, MCStatusMixin):
         self.logger.debug("Sending SLP to {}".format(self._address))
 
         try:
-            self._server.ping(retries=self._retries)
+            self._server.ping(tries=self._retries)
             return "Server is online"
         except socket.timeout as error:
             pass
@@ -45,7 +45,7 @@ class PlayersOnline(Activity, MCStatusMixin):
         self.logger.debug("Sending SLP to {}".format(self._address))
 
         try:
-            status = self._server.status(retries=self._retries)
+            status = self._server.status(tries=self._retries)
             if status.players.online > self._treshold:
                 return "{} players online on {}".format(
                     status.players.online,


### PR DESCRIPTION
Disclaimer: I don't program in Python that often so I'm not that familiar with the language.

I've noticed that the upstream mcstatus (pulled by pip) package has changed the arguments being parsed, so I've made the fix for that change.